### PR TITLE
Fix XSS in all messages using the pod's name.

### DIFF
--- a/api.php
+++ b/api.php
@@ -22,8 +22,9 @@ EOF;
  }
  $numrows = pg_num_rows($result);
 while ($row = pg_fetch_array($result)) {
+$pod_name = htmlentities($row["name"], ENT_QUOTES);
 $tip="";
-$tip.="\n This pod {$row["name"]} has been watched for {$row["monthsmonitored"]} months and its average ping time is {$row["responsetimelast7"]} with uptime of {$row["uptimelast7"]}% this month and was last checked on {$row["dateupdated"]}. ";
+$tip.="\n This pod {$pod_name} has been watched for {$row["monthsmonitored"]} months and its average ping time is {$row["responsetimelast7"]} with uptime of {$row["uptimelast7"]}% this month and was last checked on {$row["dateupdated"]}. ";
 $tip.="On a score of -20 to +20 this pod is a {$row["score"]} right now";
 if ($row["secure"] == "true") {$method = "https://";} else {$method = "http://";}
 echo <<<EOF

--- a/cleanup.php
+++ b/cleanup.php
@@ -63,7 +63,8 @@ $tip="This pod does not offer SSL";
 $verdiff =  str_replace(".", "", $row["masterversion"]) - str_replace('.', '', $row["shortversion"]);
 
 
-$tip.="\n This pod {$row["name"]} has been watched for {$row["monthsmonitored"]} months and its average ping time is {$row["responsetimelast7"]} with uptime of {$row["uptimelast7"]}% this month and was last checked on {$row["dateupdated"]}. "; 
+$pod_name = htmlentities($row["name"], ENT_QUOTES);
+$tip.="\n This pod {$pod_name} has been watched for {$row["monthsmonitored"]} months and its average ping time is {$row["responsetimelast7"]} with uptime of {$row["uptimelast7"]}% this month and was last checked on {$row["dateupdated"]}. ";
 $tip.="On a score of -20 to +20 this pod is a {$row["score"]} right now";
 
      echo "<tr><td><a class='$class' target='new' href='". $method . $row["domain"] ."'>" . $row["domain"] . " <div title='$tip' class='tipsy' style='display: inline-block'>?</div></a></td>";

--- a/show.php
+++ b/show.php
@@ -52,7 +52,8 @@ $class="red";
 $tip="This pod does not offer SSL";
 } 
 $verdiff =  str_replace(".", "", $row["masterversion"]) - str_replace('.', '', $row["shortversion"]);
-$tip.="\n This {$row["softwarename"]} pod {$row["name"]} has been watched for {$row["monthsmonitored"]} months and with an uptime of {$row["uptimelast7"]}% this month and was last checked on {$row["dateupdated"]}. "; 
+$pod_name = htmlentities($row["name"], ENT_QUOTES);
+$tip.="\n This {$row["softwarename"]} pod {$pod_name} has been watched for {$row["monthsmonitored"]} months and with an uptime of {$row["uptimelast7"]}% this month and was last checked on {$row["dateupdated"]}. ";
 $tip.="On a scale of -20 to +20 this pod is a {$row["score"]} right now";
      echo "<tr><td><a class='$class' target='new' href='". $method . $row["domain"] ."'>" . $row["domain"] . "</a> <div title='$tip' class='tipsy morehover'> ?</div></td>";
 "</div></td>";

--- a/showfull.php
+++ b/showfull.php
@@ -69,7 +69,8 @@ $tip="This pod does not offer SSL";
 $verdiff =  str_replace(".", "", $row["masterversion"]) - str_replace('.', '', $row["shortversion"]);
 
 
-$tip.="\n This {$row["softwarename"]} pod {$row["name"]} has been watched for {$row["monthsmonitored"]} months with an uptime of {$row["uptimelast7"]}% this month and a response time average today of {$row["responsetimelast7"]}ms was last checked on {$row["dateupdated"]}. "; 
+$pod_name = htmlentities($row["name"], ENT_QUOTES);
+$tip.="\n This {$row["softwarename"]} pod {$pod_name} has been watched for {$row["monthsmonitored"]} months with an uptime of {$row["uptimelast7"]}% this month and a response time average today of {$row["responsetimelast7"]}ms was last checked on {$row["dateupdated"]}. ";
 $tip.="On a scale of -20 to +20 this pod is a {$row["score"]} right now";
 
      echo "<tr><td><a class='$class' target='new' href='". $method . $row["domain"] ."'>" . $row["domain"] . " <div title='$tip' class='tipsy' style='display: inline-block'>?</div></a></td>";

--- a/showmap.php
+++ b/showmap.php
@@ -37,9 +37,10 @@ $numrows = pg_num_rows($result);
      if ($row["service_tumblr"] == "t") {$feat.= "<div id=\'tumblr\' class=\'smlogo\'></div>";}
      if ($row["service_wordpress"] == "t") {$feat.= "<div id=\'wordpress\' class=\'smlogo\'></div>";}
 unset($signup);if ($row["signup"] == 1) {$signup = "yes";} else {$signup= "no";}
+     $pod_name = htmlentities($row["name"], ENT_QUOTES);
 echo <<<EOF
-{ "type": "Feature", "id":"1", "properties": 
-{ "html":"{$row["name"]}<br><a href=\'http://{$row["domain"]}\'>Visit</a> {$row["domain"]}<br> Open Signup: {$signup}<br> Users: {$row["active_users_halfyear"]}<br> Uptime: {$row["uptimelast7"]}%<br> Services:{$feat}" }, "geometry": { "type": "Point", "coordinates": [{$row["long"]},{$row["lat"]} ] } },
+{ "type": "Feature", "id":"1", "properties":
+{ "html":"{$pod_name}<br><a href=\'http://{$row["domain"]}\'>Visit</a>{$row["domain"]}<br> Open Signup: {$signup}<br> Users: {$row["active_users_halfyear"]}<br> Uptime: {$row["uptimelast7"]}%<br> Services:{$feat}" }, "geometry": { "type": "Point", "coordinates": [{$row["long"]},{$row["lat"]} ] } },
 EOF;
 }
 ?>


### PR DESCRIPTION
This commit fixes a Persistent XSS. The problem was that at no point the output
was sanitized, allowing each pod to control the column 'name' in the database.
Since this can be set to anything one wants it can be malicious.
Using htmlentities(name, ENT_QUOTES) should be sufficient to ward this off.

------

I have found about this due to my pod's name having an apostrophe, cutting off text at first. A quick check in the HTML confirmed my fears, and a check in the codebase found the source. 

This PR should fix *that* instance of the problem, but looking at the codebase I can see a deeper problem as it does not seem maintainable. But I digress.

This has not been tested extensively, so please do scrutinize and test it locally before merging, I would not want to create additional security issues.