### PR TITLE
Improve config.php file inclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.php

--- a/api.php
+++ b/api.php
@@ -1,8 +1,9 @@
 <?php
-
 //Copyright (c) 2011, David Morley. This file is licensed under the Affero General Public License version 3 or later. See the COPYRIGHT file.
 if ($_GET['key'] != "4r45tg") {die;}
-include('db/config.php');
+
+require_once __DIR__ . '/config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());

--- a/cleanup.php
+++ b/cleanup.php
@@ -1,6 +1,7 @@
 <?php
 $tt=0;
- include('db/config.php');
+require_once __DIR__ . '/config.php';
+
  $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
  if (!$dbh) {
      die("Error in connection: " . pg_last_error());

--- a/config.php.example
+++ b/config.php.example
@@ -1,17 +1,17 @@
 <?php
 /* Copyright (c) 2011, David Morley. This file is licensed under the Affero General Public License version 3 or later. See the COPYRIGHT file. */
 //backup directory
-$backup_dir = "/var/www/podup/backup";
+$backup_dir = '/var/www/podup/backup';
 //log directory
-$log_dir = "/var/www/podup/log";
+$log_dir = '/var/www/podup/log';
 //location of pg dump
-$pg_dump_dir = "/usr/bin";
+$pg_dump_dir = '/usr/bin';
 //db username
-$pguser='';
+$pguser = '';
 //db password
-$pgpass='';
+$pgpass = '';
 //db name
-$pgdb='';
+$pgdb = '';
 //admin email for forms
 $adminemail = '';
 //admin key for deleting pods, set this as a cookie on your own
@@ -20,4 +20,3 @@ $adminkey = '';
 $chimpkey = '';
 //apikey for public api calls
 $apikey= '';
-?>

--- a/db/add.php
+++ b/db/add.php
@@ -1,8 +1,8 @@
 <!-- /* Copyright (c) 2011, David Morley. This file is licensed under the Affero General Public License version 3 or later. See the COPYRIGHT file. */ -->
 <?php
 $valid=0;
-include('config.php');
-include('../logging.php');
+require_once __DIR__ . '/../logging.php';
+
 $log = new Logging();
 $log->lfile($log_dir."/add.php.log");
 if (!$_POST['url']){
@@ -25,6 +25,9 @@ if (strlen($_POST['url']) < 14){
   echo "API key bad needs to be like m58978-80abdb799f6ccf15e3e3787ee";$log->lwrite('api key too short '.$_POST['domain']);
   die;
 }
+
+require_once __DIR__ . '/../config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());

--- a/db/api-more.php
+++ b/db/api-more.php
@@ -1,7 +1,8 @@
 <?php
 //Copyright (c) 2011, David Morley. This file is licensed under the Affero General Public License version 3 or later. See the COPYRIGHT file.
 //this is just a single api for a pod for the android app to get data
-include('config.php');
+require_once __DIR__ . '/../config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());

--- a/db/backup.php
+++ b/db/backup.php
@@ -1,5 +1,6 @@
 <?php
-include('config.php');
+require_once __DIR__ . '/../config.php';
+
 $keep = (60 * 60 * 6) * 1; 
 $dump_date = date("Ymd_Hs");
 $file_name = $backup_dir . "/dump_" . $dump_date . ".sql";

--- a/db/edit.php
+++ b/db/edit.php
@@ -1,5 +1,4 @@
 <?php
-include('config.php');
 if (!$_GET['domain']){
   echo "no pod domain given";
   die;
@@ -13,6 +12,9 @@ if (strlen($_GET['token']) < 6){
   die;
 }
 $domain = $_GET['domain'];
+
+require_once __DIR__ . '/../config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());

--- a/db/gettoken.php
+++ b/db/gettoken.php
@@ -1,11 +1,13 @@
 <?php
-include('config.php');
 $systemTimeZone = system('date +%Z');
 if (!$_POST['domain']){
   echo "no pod domain given";
   die;
 }
 $domain = $_POST['domain'];
+
+require_once __DIR__ . '/../config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());

--- a/db/kill.php
+++ b/db/kill.php
@@ -1,5 +1,4 @@
 <?php
-include('config.php');
 if (!$_POST['domain']){
   echo "no pod domain given";
   die;
@@ -12,8 +11,10 @@ if (!$_POST['action']){
   echo "no action selected";
   die;
 }
-
 $domain = $_POST['domain'];
+
+require_once __DIR__ . '/../config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());

--- a/db/pull.php
+++ b/db/pull.php
@@ -3,7 +3,7 @@ $debug = isset($_GET['debug'])?1:0;
 $debug=1;
 //$debug = isset($argv[1])?1:0;
 //* Copyright (c) 2011, David Morley. This file is licensed under the Affero General Public License version 3 or later. See the COPYRIGHT file. */
-include('config.php');
+require_once __DIR__ . '/../config.php';
 
 //get master code version for diaspora pods
 $mv = curl_init();

--- a/db/saverating.php
+++ b/db/saverating.php
@@ -1,5 +1,4 @@
 <?php
-include('config.php');
 if (!$_POST['username']){
   echo "no username given";
   die;
@@ -20,6 +19,9 @@ if (!$_POST['rating']){
   echo "no rating given";
   die;
 }
+
+require_once __DIR__ . '/../config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());

--- a/db/showuptimerobot.php
+++ b/db/showuptimerobot.php
@@ -1,7 +1,8 @@
 <?php
 $debug=1;
 //* Copyright (c) 2011-2016, David Morley. This file is licensed under the Affero General Public License version 3 or later. See the COPYRIGHT file. */
-include('config.php');
+require_once __DIR__ . '/../config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {die("Error in connection: " . pg_last_error());}
 $domain = isset($_GET['domain'])?$_GET['domain']:null;

--- a/random.php
+++ b/random.php
@@ -1,5 +1,6 @@
 <?php
-include('db/config.php');
+require_once __DIR__ . '/config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());

--- a/rate.php
+++ b/rate.php
@@ -36,7 +36,8 @@ $("#slider").slider({ animate: true, max: 10, min: 1, step: 1, value: 10, stop: 
 <body>
 <div style="height:500px;width:900px;">
 <?php
-include('db/config.php');
+require_once __DIR__ . '/config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());

--- a/show.php
+++ b/show.php
@@ -1,6 +1,7 @@
 <?php
 $tt=0;
-include('db/config.php');
+require_once __DIR__ . '/config.php';
+
 $country_code = $_SERVER["HTTP_CF_IPCOUNTRY"];
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {

--- a/showfull.php
+++ b/showfull.php
@@ -1,6 +1,7 @@
 <?php
 $tt=0;
-include('db/config.php');
+require_once __DIR__ . '/config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());

--- a/showmap.php
+++ b/showmap.php
@@ -19,7 +19,8 @@ var geoJsonData = {
 "type": "FeatureCollection",
 "features": [
 <?php
-include('db/config.php');
+require_once __DIR__ . '/config.php';
+
 $dbh = pg_connect("dbname=$pgdb user=$pguser password=$pgpass");
 if (!$dbh) {
   die("Error in connection: " . pg_last_error());


### PR DESCRIPTION
Move config.php to the root level, as it doesn't only have the DB connection info.
Instead of just including the config, it must be required, as it is an essential file.
Move require statement below $_GET checks.