### PR TITLE
revert curl time for latency value

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ touch add.log in location you configured in config.php
 
 run db/pull.sh manually or with cron to update your data
 
+To Upgrade:
+```
+cd Poduptime
+git pull
+bower install
+psql -u podupuser podupdb < db/migrationx.sql (see db/version.md for proper migration version)
+```
+
 ============================
 
 Source for Diaspora Pod Uptime

--- a/db/pull.php
+++ b/db/pull.php
@@ -63,7 +63,7 @@ while ($row = pg_fetch_assoc($result)) {
   $outputssl      = curl_exec($chss);
   $outputsslerror = curl_error($chss);
   $info           = curl_getinfo($chss, CURLINFO_CERTINFO);
-  $latency        = curl_getinfo($chss, CURLINFO_TOTAL_TIME);
+  $latency        = curl_getinfo($chss, CURLINFO_CONNECT_TIME);
   $sslexpire      = $info[0]['Expire date'] ?? null;
   curl_close($chss);
 

--- a/db/pull.php
+++ b/db/pull.php
@@ -63,13 +63,17 @@ while ($row = pg_fetch_assoc($result)) {
   $outputssl      = curl_exec($chss);
   $outputsslerror = curl_error($chss);
   $info           = curl_getinfo($chss, CURLINFO_CERTINFO);
-  $latency        = curl_getinfo($chss, CURLINFO_CONNECT_TIME);
+  $conntime       = curl_getinfo($chss, CURLINFO_CONNECT_TIME);
+  $nstime         = curl_getinfo($chss, CURLINFO_NAMELOOKUP_TIME);
+  $latency        = $conntime - $nstime;
   $sslexpire      = $info[0]['Expire date'] ?? null;
   curl_close($chss);
 
   _debug('Nodeinfo output', $outputssl, true);
   _debug('Nodeinfo output error', $outputsslerror, true);
   _debug('Cert expire date', $sslexpire);
+  _debug('Conntime', $conntime);
+  _debug('NStime', $nstime);
   _debug('Latency', $latency);
   
   $jsonssl = json_decode($outputssl);

--- a/db/version.md
+++ b/db/version.md
@@ -1,8 +1,8 @@
 If new install import tables.sql
 
 If upgrading migrations are:
-migration00001.sql
+v1.0 -> v2.0 = migration00001.sql
 
-To support the original apiv1 you should run:
+To support the original apiv1 you should import:
 pods_apiv1.sql 
-into your db daily at least.
+into your db as often as you want your api updated.

--- a/showfull.php
+++ b/showfull.php
@@ -27,7 +27,7 @@ $numrows = pg_num_rows($result);
     <th><a data-toggle="tooltip" data-placement="bottom" title="Type of software this pod runs">Software</a></th>
     <th><a data-toggle="tooltip" data-placement="bottom" title="Percent of the time the pod is online.">Uptime</a></th>
     <th><a data-toggle="tooltip" data-placement="bottom" title="Does this pod offer ipv6 connection.">IPv6</a></th>
-    <th><a data-toggle="tooltip" data-placement="bottom" title="Average connection latency time in ms.">Latency</a></th>
+    <th><a data-toggle="tooltip" data-placement="bottom" title="Average connection latency time in ms from Los Angeles.">Latency</a></th>
     <th><a data-toggle="tooltip" data-placement="bottom" title="Does this pod allow new users.">Signups</a></th>
     <th><a data-toggle="tooltip" data-placement="bottom" title="Number of total users on this pod.">Users</a></th>
     <th><a data-toggle="tooltip" data-placement="bottom" title="Number of users active last 6 months on this pod.">Active 6m</a></th>


### PR DESCRIPTION
I was wrong to move to TOTAL_TIME, it seemed logical but as you watch the more users on a pod the longer nodeinfo takes to compile, it's not cached or anything, so a pod can have more users and be shown as 7 seconds, really not that bad, but I think 7000ms will scare away users since our brains are looking for 30-100ms as good latency time on connections. 